### PR TITLE
api: fix errors about shirt enum

### DIFF
--- a/api/app.py
+++ b/api/app.py
@@ -58,7 +58,7 @@ def avatar():
     svg = pa.Avatar(
         style=pa.AvatarStyle.CIRCLE,
         background_color='#03C7D3',
-        clothing=pa.ClothingType.TILT_SHIRT,
+        clothing='tilt_shirt',
         clothing_color='#20BA31',
         **params
     ).render()


### PR DESCRIPTION
Lian encountered this a while back and I wasn't able to reproduce
it consistently enough to fix, but tracked it down today. The
avatar library does some sketchy stuff with the enums to allow you
to add new entries, which I think is racy without restarting
Python interpeter.

By using the filename string, the lookup works reliably.