### PR TITLE
Freeze werkzeug version

### DIFF
--- a/api/requirements.txt
+++ b/api/requirements.txt
@@ -1,2 +1,3 @@
 flask~=2.1.1
 python-avatars~=1.3.0
+werkzeug~=2.3.7


### PR DESCRIPTION
Avoid installing werkzeug 3, as it breaks flask

Trying to go through tilt tutorial gives me the following:
```
Traceback (most recent call last):
  File "/usr/local/bin/flask", line 5, in <module>
    from flask.cli import main
  File "/usr/local/lib/python3.10/site-packages/flask/__init__.py", line 7, in <module>
    from .app import Flask as Flask
  File "/usr/local/lib/python3.10/site-packages/flask/app.py", line 27, in <module>
    from . import cli
  File "/usr/local/lib/python3.10/site-packages/flask/cli.py", line 17, in <module>
    from .helpers import get_debug_flag
  File "/usr/local/lib/python3.10/site-packages/flask/helpers.py", line 14, in <module>
    from werkzeug.urls import url_quote
ImportError: cannot import name 'url_quote' from 'werkzeug.urls' (/usr/local/lib/python3.10/site-packages/werkzeug/urls.py)
```

This fixes it, and now I'm able to continue the tutorial.